### PR TITLE
Fixed the Starwalker actor to show sprite properly.

### DIFF
--- a/scripts/data/actors/starwalker.lua
+++ b/scripts/data/actors/starwalker.lua
@@ -20,7 +20,7 @@ function actor:init()
     self.flip = nil
 
     -- Path to this actor's sprites (defaults to "")
-    self.path = "npcs/starwalker"
+    self.path = "npcs/starwalker2"
     -- This actor's default sprite or animation, relative to the path (defaults to "")
     self.default = ""
 


### PR DESCRIPTION
A very small pull request. This one fixes the broken sprite path in Starwalker's actor file, which caused the actor to be invisible on the map during gameplay.