### PR TITLE
Save point/menu tweaks

### DIFF
--- a/libraries/Ultimate RIBBIT/scripts/hooks/LightSaveMenu.lua
+++ b/libraries/Ultimate RIBBIT/scripts/hooks/LightSaveMenu.lua
@@ -16,11 +16,58 @@ function LightSaveMenu:update()
         if sound == "save" and Kristal.callEvent("isLeaderRibbit") then
             sound = "savefrog"
         end
+        Assets.stopSound("powerfrog")
         return _playSound(sound, ...)
     end
     local result, info = pcall(super.update, self)
     Assets.playSound = _playSound
     if not result then error(info) end
+end
+
+--This kinda sucks ass but I'm not entirely sure how I should edit this function without copying it entirely
+-- Please someone make this better - Agent 7
+function LightSaveMenu:draw()
+    love.graphics.setFont(self.font)
+
+    if self.state == "SAVED" then
+        Draw.setColor(PALETTE["world_text_selected"])
+    else
+        Draw.setColor(PALETTE["world_text"])
+    end
+
+    local data      = self.saved_file or {}
+    local name      = data.name      or "Kris"
+    local level     = data.level     or 1
+    local playtime  = data.playtime  or 0
+    local room_name = data.room_name or ""
+
+    love.graphics.print(name,         self.box.x + 8,        self.box.y - 10 + 8)
+    love.graphics.print("LV "..level, self.box.x + 210 - 34, self.box.y - 10 + 8)
+
+    local minutes = math.floor(playtime / 60)
+    local seconds = math.floor(playtime % 60)
+    local time_text = string.format("%d:%02d", minutes, seconds)
+    love.graphics.printf(time_text, self.box.x - 280 + 148, self.box.y - 10 + 8, 500, "right")
+
+    love.graphics.print(room_name, self.box.x + 8, self.box.y + 38)
+
+    if self.state == "MAIN" then
+        love.graphics.print("Save",   self.box.x + 30  + 8, self.box.y + 98)
+        love.graphics.print("Return", self.box.x + 210 + 8, self.box.y + 98)
+
+        Draw.setColor(Game:getSoulColor())
+        Draw.draw(self.heart_sprite, self.box.x + 10 + (self.selected_x - 1) * 180, self.box.y + 96 + 8, 0, 2, 2)
+    elseif self.state == "SAVED" then
+        if Kristal.callEvent("isLeaderRibbit") then
+            love.graphics.print("There we go.", self.box.x + 30, self.box.y + 90)
+        else
+            love.graphics.print("File saved.", self.box.x + 30, self.box.y + 90)
+        end
+    end
+
+    Draw.setColor(1, 1, 1)
+
+    --super.draw(self)
 end
 
 return LightSaveMenu

--- a/libraries/Ultimate RIBBIT/scripts/hooks/SaveMenu.lua
+++ b/libraries/Ultimate RIBBIT/scripts/hooks/SaveMenu.lua
@@ -12,11 +12,64 @@ function SaveMenu:update()
         if sound == "save" and Kristal.callEvent("isLeaderRibbit") then
             sound = "savefrog"
         end
+        Assets.stopSound("powerfrog")
         return _playSound(sound, ...)
     end
     local result, info = pcall(super.update, self)
     Assets.playSound = _playSound
     if not result then error(info) end
+end
+
+--This kinda sucks ass but I'm not entirely sure how I should edit this function without copying it entirely
+-- Please someone make this better - Agent 7
+function SaveMenu:drawSaveFile(index, data, x, y, selected, header)
+    if self.saved_file then
+        if self.saved_file == index then
+            Draw.setColor(PALETTE["world_text_selected"])
+        else
+            Draw.setColor(PALETTE["world_save_other"])
+        end
+    else
+        if selected then
+            Draw.setColor(PALETTE["world_text_selected"])
+        else
+            Draw.setColor(PALETTE["world_text"])
+        end
+    end
+    if self.saved_file == index and not header then
+        if Kristal.callEvent("isLeaderRibbit") then
+            love.graphics.print("There we go.", x + 180, y + 22)
+        else
+            love.graphics.print("File Saved", x + 180, y + 22)
+        end
+    elseif not data then
+        love.graphics.print("New File", x + 193, y + 22)
+        if selected then
+            Draw.setColor(Game:getSoulColor())
+            Draw.draw(self.heart_sprite, x + 161, y + 30)
+        end
+    else
+        if self.saved_file or header then
+            love.graphics.print("LV "..data.level, x + 26, y + 6)
+        else
+            love.graphics.print("LV "..data.level, x + 50, y + 6)
+        end
+
+        love.graphics.print(data.name, x + (493 / 2) - self.font:getWidth(data.name) / 2, y + 6)
+
+        local minutes = math.floor(data.playtime / 60)
+        local seconds = math.floor(data.playtime % 60)
+        local time_text = string.format("%d:%02d", minutes, seconds)
+        love.graphics.print(time_text, x + 467 - self.font:getWidth(time_text), y + 6)
+
+        love.graphics.print(data.room_name, x + (493 / 2) - self.font:getWidth(data.room_name) / 2, y + 38)
+
+        if selected and not header then
+            Draw.setColor(Game:getSoulColor())
+            Draw.draw(self.heart_sprite, x + 18, y + 14)
+        end
+    end
+    Draw.setColor(1, 1, 1)
 end
 
 return SaveMenu

--- a/libraries/Ultimate RIBBIT/scripts/hooks/Savepoint.lua
+++ b/libraries/Ultimate RIBBIT/scripts/hooks/Savepoint.lua
@@ -5,7 +5,11 @@ end
 local Savepoint, super = Class("Savepoint", true)
 
 function Savepoint:onInteract(player, dir)
-    Assets.playSound(Kristal.callEvent("isLeaderRibbit") and "powerfrog" or "power")
+    if Kristal.callEvent("isLeaderRibbit") then
+        Assets.playSound("powerfrog")
+    elseif not Kristal.callEvent("isLeaderRibbit") then -- Don't know WHY I need to specify this, but "power" plays anyway if I make it just "else".
+        Assets.playSound("power")
+    end
 
     if self.text_once and self.used then
         self:onTextEnd()
@@ -20,10 +24,12 @@ function Savepoint:onInteract(player, dir)
     return true
 end
 
+--[[
 function Savepoint:onTextEnd()
     super.onTextEnd(self)
 
     Assets.stopSound("powerfrog")
 end
+--]]
 
 return Savepoint

--- a/libraries/Ultimate RIBBIT/scripts/hooks/SimpleSaveMenu.lua
+++ b/libraries/Ultimate RIBBIT/scripts/hooks/SimpleSaveMenu.lua
@@ -12,11 +12,58 @@ function SimpleSaveMenu:update()
         if sound == "save" and Kristal.callEvent("isLeaderRibbit") then
             sound = "savefrog"
         end
+        Assets.stopSound("powerfrog")
         return _playSound(sound, ...)
     end
     local result, info = pcall(super.update, self)
     Assets.playSound = _playSound
     if not result then error(info) end
+end
+
+--This kinda sucks ass but I'm not entirely sure how I should edit this function without copying it entirely
+-- Please someone make this better - Agent 7
+function SimpleSaveMenu:draw()
+    love.graphics.setFont(self.font)
+
+    if self.state == "SAVED" then
+        Draw.setColor(PALETTE["world_text_selected"])
+    else
+        Draw.setColor(PALETTE["world_text"])
+    end
+
+    local data = self.saved_file or {}
+    local name      = data.name      or "[EMPTY]"
+    local level     = data.level     or 0
+    local playtime  = data.playtime  or 0
+    local room_name = data.room_name or ""
+
+    love.graphics.print(name,         self.box.x,       self.box.y - 10)
+    love.graphics.print("LV "..level, self.box.x + 210, self.box.y - 10)
+
+    local minutes = math.floor(playtime / 60)
+    local seconds = math.floor(playtime % 60)
+    local time_text = string.format("%d:%02d", minutes, seconds)
+    love.graphics.print(time_text, self.box.x + 280, self.box.y - 10)
+
+    love.graphics.print(room_name, self.box.x, self.box.y + 30)
+
+    if self.state == "MAIN" then
+        love.graphics.print("Save",   self.box.x + 30,  self.box.y + 90)
+        love.graphics.print("Return", self.box.x + 210, self.box.y + 90)
+
+        Draw.setColor(Game:getSoulColor())
+        Draw.draw(self.heart_sprite, self.box.x + 2 + (self.selected_x - 1) * 180, self.box.y + 96)
+    elseif self.state == "SAVED" then
+        if Kristal.callEvent("isLeaderRibbit") then
+            love.graphics.print("There we go.", self.box.x + 30, self.box.y + 90)
+        else
+            love.graphics.print("File saved.", self.box.x + 30, self.box.y + 90)
+        end
+    end
+
+    Draw.setColor(1, 1, 1)
+
+    --super.draw(self)
 end
 
 return SimpleSaveMenu


### PR DESCRIPTION
Made the following changes:

- Interacting with save points no longer plays `power` on top of `powerfrog`
- `powerfrog` now correctly plays on save points without flavor text
- Changed the "File Saved" text to "There we go."
  - The way I did this one sucks please find a better way to do it

All of these changes rely on the party leader being a Ribbit character, of course. If that's not the case, then none of these changes will actually do anything.
