### PR TITLE
Fix taunting at incorrect times

### DIFF
--- a/scripts/hooks/Soul.lua
+++ b/scripts/hooks/Soul.lua
@@ -128,7 +128,7 @@ function Soul:update()
         self.parry_sfx:play()
 
         for _,chara in pairs(Game.battle.stage:getObjects(PartyBattler)) do
-            if not chara.actor then goto continue end
+            if not chara.actor or chara.is_down then goto continue end
 
             -- workaround due of actors being loaded first by registry
             local sprites = chara.actor.getTauntSprites and chara.actor:getTauntSprites() or chara.actor.taunt_sprites

--- a/scripts/main/ow_taunt.lua
+++ b/scripts/main/ow_taunt.lua
@@ -18,7 +18,7 @@ function Mod:updateTaunt()
         (Game.party[1]:checkArmor("pizza_toque") or Game.save_name:upper() == "PEPPINO" or self.let_me_taunt)
         and Input.pressed("v", false)
         and self.taunt_cooldown == 0
-        and (Game.state == "OVERWORLD" and Game.world.state == "GAMEPLAY" and not Game.world:hasCutscene() and not Game.lock_movement)
+        and (Game.state == "OVERWORLD" and Game.world.state == "GAMEPLAY" and not Game.world:hasCutscene() and not Game.lock_movement and not Kristal.Console.is_open and not Kristal.DebugSystem:isMenuOpen())
     then
         self.taunt_cooldown = 0.4
         self.taunt_lock_movement = true


### PR DESCRIPTION
Downed party members will no longer taunt in battle, and you can no longer taunt when the console or debug menu is open.