### PR TITLE
Made the PizzaToque work regardless of who's wearing it

### DIFF
--- a/scripts/hooks/Player.lua
+++ b/scripts/hooks/Player.lua
@@ -3,9 +3,12 @@ local Player, super = Class("Player", true)
 
 function Player:update()
     -- Holding run with the Pizza Toque equipped (or if the file name is "PEPPINO") will cause a gradual increase in speed.
-    local player = Game.party[1]
+    toque_equipped = false
+    for _,party in ipairs(Game.party) do
+        if party:checkArmor("pizza_toque") then toque_equipped = true end
+    end
     local player_name = Game.save_name:upper()
-    if player:checkArmor("pizza_toque") or player_name == "PEPPINO" then
+    if toque_equipped == true or player_name == "PEPPINO" then
         if self.run_timer > 60 then
             self.walk_speed = self.walk_speed + DT
         elseif self.walk_speed > 4 then
@@ -16,7 +19,7 @@ function Player:update()
     super.update(self)
 
     -- Hitting a wall at a speed of 10 or higher will do a small collision effect
-    if player:checkArmor("pizza_toque") or player_name == "PEPPINO" then
+    if toque_equipped == true or player_name == "PEPPINO" then
         if self.last_collided_x or self.last_collided_y then
             if self.walk_speed >= 10 then
                 Game.world.player:shake(4, 0)
@@ -27,7 +30,7 @@ function Player:update()
 
     --[[
     Old code that will either explode the player or do 20 damage to the party depending on their speed when hitting a wall.
-    if player:checkArmor("pizza_toque") or player_name == "PEPPINO" then
+    if toque_equipped == true or player_name == "PEPPINO" then
         if self.last_collided_x or self.last_collided_y then
                 if self.walk_speed >= 16 then
                     self:explode()

--- a/scripts/hooks/Soul.lua
+++ b/scripts/hooks/Soul.lua
@@ -92,9 +92,15 @@ function Soul:update()
 
 	local player = Game.party[1]
 	local player_name = Game.save_name:upper()
+    local toque_equipped = false
+    local focus_equipped = false
+	for _,party in ipairs(Game.party) do
+        if party:checkArmor("pizza_toque") then toque_equipped = true end
+        if party:checkArmor("focus") then focus_equipped = true end
+    end
 	-- Taunt code starts here
 	if self.force_taunt ~= false then
-	if player:checkArmor("pizza_toque") or player_name == "PEPPINO" or self.force_taunt == true then
+	if toque_equipped or player_name == "PEPPINO" or self.force_taunt == true then
 	if self.transitioning then
         if self.parried_loop_sfx then
             self.parried_loop_sfx:stop()
@@ -167,7 +173,7 @@ function Soul:update()
 
 	-- Focus code starts here
 	if self.force_timeslow ~= false then
-	if player:checkArmor("focus") or self.force_timeslow == true then
+	if focus_equipped or self.force_timeslow == true then
 	if not self.transitioning then
         outlinefx.active = true
     end

--- a/scripts/main/ow_taunt.lua
+++ b/scripts/main/ow_taunt.lua
@@ -14,11 +14,16 @@ function Mod:initTaunt()
 end
 
 function Mod:updateTaunt()
+    local toque_equipped = false
+    for _,party in ipairs(Game.party) do
+        if party:checkArmor("pizza_toque") then toque_equipped = true end
+    end
     if
-        (Game.party[1]:checkArmor("pizza_toque") or Game.save_name:upper() == "PEPPINO" or self.let_me_taunt)
+        (toque_equipped == true or Game.save_name:upper() == "PEPPINO" or self.let_me_taunt)
         and Input.pressed("v", false)
         and self.taunt_cooldown == 0
-        and (Game.state == "OVERWORLD" and Game.world.state == "GAMEPLAY" and not Game.world:hasCutscene() and not Game.lock_movement and not Kristal.Console.is_open and not Kristal.DebugSystem:isMenuOpen())
+        and (Game.state == "OVERWORLD" and Game.world.state == "GAMEPLAY" and not Game.world:hasCutscene() and not Game.lock_movement
+        and not Kristal.Console.is_open and not Kristal.DebugSystem:isMenuOpen())
     then
         self.taunt_cooldown = 0.4
         self.taunt_lock_movement = true


### PR DESCRIPTION
No longer has to be worn by the party leader for taunting to be enabled. Did the same for the focus placebo once that's obtainable.