### PR TITLE
Timeslow FX improvement + "Fix" inf dummy crash

### DIFF
--- a/scripts/battle/cutscenes/dummy.lua
+++ b/scripts/battle/cutscenes/dummy.lua
@@ -19,8 +19,8 @@ return {
 
         Kristal.callEvent("completeAchievement", "dummy")
     end,
-	
+
 	end_battle = function(cutscene)
-		Game.battle:returnToWorld()
+		Game.battle:returnToWorld() -- don't do this pls it crashes
 	end
 }

--- a/scripts/battle/enemies/inf_dummy.lua
+++ b/scripts/battle/enemies/inf_dummy.lua
@@ -51,7 +51,7 @@ end
 
 function Dummy:onAct(battler, name)
     if name == "Stop" then
-		Game.battle:startActCutscene("dummy.end_battle")
+		Game.battle:setState("TRANSITIONOUT")
 
     elseif name == "Standard" then
         return "* "..battler.chara:getName().." did something.."

--- a/scripts/hooks/Battle.lua
+++ b/scripts/hooks/Battle.lua
@@ -454,4 +454,31 @@ function Battle:processAction(action)
     end
 end
 
+
+-- Failed attempt at recreating the CONCENTRATING thing, uncomment for a kinda cool effect
+--[[
+function Battle:drawBackground()
+    Draw.setColor(0, 0, 0, self.transition_timer / 10)
+    love.graphics.rectangle("fill", -8, -8, SCREEN_WIDTH+16, SCREEN_HEIGHT+16)
+
+    love.graphics.setLineStyle("rough")
+    love.graphics.setLineWidth(1)
+
+
+    --for i = 2, 16 do
+    --    Draw.setColor(66 / 255, 0, 66 / 255, (self.transition_timer / 10) / 2)
+    --    love.graphics.line(0, -210 + (i * 50) + math.floor(self.offset / 2), 640, -210 + (i * 50) + math.floor(self.offset / 2))
+    --    love.graphics.line(-200 + (i * 50) + math.floor(self.offset / 2), 0, -200 + (i * 50) + math.floor(self.offset / 2), 480)
+    --end
+    
+
+    --
+    for i = 3, 16 do
+        Draw.setColor(66 / 255, 0, 66 / 255, self.transition_timer / 10)
+        love.graphics.draw(Assets.getTexture("objects/concentrating"), 0, -100 + (i * 50) - math.floor(self.offset), 640, -100 + (i * 50) - math.floor(self.offset))
+        love.graphics.line(-100 + (i * 50) - math.floor(self.offset), 0, -100 + (i * 50) - math.floor(self.offset), 480)
+    end
+end
+--]]
+
 return Battle

--- a/scripts/objects/ConcentrateBG.lua
+++ b/scripts/objects/ConcentrateBG.lua
@@ -1,0 +1,54 @@
+-- Yes this is just StarsBG I'm terrible at making backgrounds like this cut me some slack here
+local ConcentrateBG, super = Class(Object)
+
+function ConcentrateBG:init(color, back_color, fill)
+    super.init(self)
+
+    self.color = color
+    self.back_color = back_color or color
+    self.fill = fill or {0, 0, 0}
+	self.offset = 0
+    self.speed = 2
+    self.size = 63
+	self.layer = BATTLE_LAYERS["bottom"]
+	self.alpha_fx = self:addFX(AlphaFX())
+    self.image = Assets.getTexture("objects/concentrating")
+    self.no_x = false
+end
+
+function ConcentrateBG:update()
+    super.update(self)
+    self.fade = Game.battle.transition_timer / 10
+	self.offset = self.offset + self.speed*DTMULT
+
+    if self.offset > self.size*2 then
+        self.offset = 0
+    end
+
+end
+
+function ConcentrateBG:draw()
+    super.draw(self)
+
+    self:drawFill()
+	self:drawFront()
+end
+
+function ConcentrateBG:drawFill()
+    local r,g,b,a = unpack(self.fill)
+    love.graphics.setColor(r,g,b, a or self.fade)
+    love.graphics.rectangle("fill", -8, -8, SCREEN_WIDTH+16, SCREEN_HEIGHT+16)
+end
+
+function ConcentrateBG:drawFront()
+    local r,g,b,a = unpack(self.color)
+    love.graphics.setColor(r,g,b, a or self.fade)
+    love.graphics.setColor(1,1,1,0.5)
+	for x = 0, 1100, 130 do
+		for y = 0, 880, 63 do
+			love.graphics.draw(self.image, x - self.offset, y - self.offset)
+		end
+	end
+end
+
+return ConcentrateBG


### PR DESCRIPTION
- The outline now applies to whoever has Focus equipped. Also added the CONCENTRATING thing seen in RIBBIT.
- The infinite dummy Stop act now just sets the battle state to `TRANSITIONOUT` instead of running `battle:returnToWorld()`, which crashes at the moment in this setup.