### PR TITLE
Blue Soul tweaks

### DIFF
--- a/libraries/blue_soul_library/scripts/objects/BlueSoul.lua
+++ b/libraries/blue_soul_library/scripts/objects/BlueSoul.lua
@@ -9,6 +9,7 @@ function BlueSoul:init(x, y, angle)
     self.ground_pounded = false
     self.gravity = 0
     self.jumps_left = 0
+	self.blue = true -- Checking this to disable the reduced hitbox for it
 
 	-- Variables that can be changed
     self.can_jump = true 		-- Can the blue soul jump? [boolean] (true; false) | default: true
@@ -60,6 +61,9 @@ function BlueSoul:doMovement()
 		else
 			self.jumped = true
 		end
+		if self.last_collided_y == -1 and self.gravity < 0 then
+			self.gravity = 0
+		end
 	elseif self.direction == "up" then
 		-- Keyboard input:
 		if Input.down("left")  then move_x = move_x - 1 end
@@ -85,6 +89,9 @@ function BlueSoul:doMovement()
 			self:jumpReset()
 		else
 			self.jumped = true
+		end
+		if self.last_collided_y == 1 and self.gravity < 0 then
+			self.gravity = 0
 		end
 	elseif self.direction == "left" then
 		-- Keyboard input:
@@ -112,6 +119,9 @@ function BlueSoul:doMovement()
 		else
 			self.jumped = true
 		end
+		if self.last_collided_x == 1 and self.gravity < 0 then
+			self.gravity = 0
+		end
 	elseif self.direction == "right" then
 		-- Keyboard input:
 		if Input.down("up")  then move_y = move_y - 1 end
@@ -137,6 +147,9 @@ function BlueSoul:doMovement()
 			self:jumpReset()
 		else
 			self.jumped = true
+		end
+		if self.last_collided_x == -1 and self.gravity < 0 then
+			self.gravity = 0
 		end
 	end
 	
@@ -177,6 +190,10 @@ function BlueSoul:jumpStart()
 	if self.can_jump then
 		if self.can_doublejump then
 			if self.jumps_left > 0 then
+				if self.jumps_left ~= self.jump_count then
+					local djumpfx = DoubleJumpEffect()
+					Game.battle:addChild(djumpfx)
+				end
 				self.gravity = -self.jump_height
 				self.jumps_left = self.jumps_left - 1*DTMULT
 			end
@@ -213,10 +230,10 @@ end
 function BlueSoul:doGravity()
 	if self.gravity >= -25 and self.gravity < -6 then self.gravity = self.gravity + 0.25*DTMULT end
 	if self.gravity >= -6 and self.gravity < -0.8 then self.gravity = self.gravity + 0.20*DTMULT end
-	if self.gravity >= -0.8 and self.gravity < 0.8 then self.gravity = self.gravity + 0.15*DTMULT end
-	if self.gravity >= 0.8 and self.gravity < 2.5 then self.gravity = self.gravity + 0.20*DTMULT end
-	if self.gravity >= 2.5 and self.gravity < 6 then self.gravity = self.gravity + 0.25*DTMULT end
-	if self.gravity >= 6 and self.gravity < 13 then self.gravity = self.gravity + 0.30*DTMULT end
+	if self.gravity >= -0.8 and self.gravity < 0.8 then self.gravity = self.gravity + 0.15*DTMULT*2 end
+	if self.gravity >= 0.8 and self.gravity < 2.5 then self.gravity = self.gravity + 0.20*DTMULT*2 end
+	if self.gravity >= 2.5 and self.gravity < 6 then self.gravity = self.gravity + 0.25*DTMULT*2 end
+	if self.gravity >= 6 and self.gravity < 13 then self.gravity = self.gravity + 0.30*DTMULT*2 end
 end
 
 return BlueSoul

--- a/scripts/hooks/Soul.lua
+++ b/scripts/hooks/Soul.lua
@@ -99,7 +99,7 @@ end
 function Soul:update()
 	super.update(self)
 
-	if Input.down("cancel") then
+	if Input.down("cancel") and not self.blue then -- Reduced hitbox size can get you stuck in collision with the blue soul, so it can't use this.
 		self.collider.radius = 4
 		self.sprite_focus.alpha = 1
 	else

--- a/scripts/objects/effects/DoubleJumpEffect.lua
+++ b/scripts/objects/effects/DoubleJumpEffect.lua
@@ -1,0 +1,49 @@
+local DoubleJumpEffect, super = Class(Object)
+
+function DoubleJumpEffect:init()
+    super.init(self)
+
+    self.timer = 0
+    self:fadeOutAndRemove(0.3)
+    if Game.battle.soul then
+        if Game.battle.soul.direction == "down" then
+            self.x = Game.battle.soul.x
+            self.y = Game.battle.soul.y + 10
+        elseif Game.battle.soul.direction == "up" then
+            self.x = Game.battle.soul.x
+            self.y = Game.battle.soul.y - 10
+        elseif Game.battle.soul.direction == "left" then
+            self.x = Game.battle.soul.x - 10
+            self.y = Game.battle.soul.y
+        elseif Game.battle.soul.direction == "right" then
+            self.x = Game.battle.soul.x + 10
+            self.y = Game.battle.soul.y
+        end
+    end
+    self.layer = BATTLE_LAYERS["soul"] - 1
+    --self.alpha = 0.75
+    self.color = COLORS.gray
+
+end
+
+function DoubleJumpEffect:update()
+    super.update(self)
+    self.timer = self.timer + 1
+    --self.alphafade = self.alphafade + 0.2
+
+end
+
+function DoubleJumpEffect:draw()
+    super.draw(self)
+    love.graphics.setLineWidth(2)
+    local soul = Game.battle.soul
+    if soul.direction == "down" or soul.direction == "up" then
+        love.graphics.ellipse("line", 0, 0, 5 + self.timer/2, 2 + self.timer/4, 100)
+        love.graphics.ellipse("line", 0, 0, 10 + self.timer, 4 + self.timer/2, 100)
+    elseif soul.direction == "left" or soul.direction == "right" then
+        love.graphics.ellipse("line", 0, 0, 2 + self.timer/4, 5 + self.timer/2, 100)
+        love.graphics.ellipse("line", 0, 0, 4 + self.timer/2, 10 + self.timer, 100)
+    end
+end
+
+return DoubleJumpEffect


### PR DESCRIPTION
- Tweaked gravity to make the soul less floaty
- Hitting a ceiling now cancels out upward momentum
- Added a small visual effect to the double jump
- Removed the reduced hitbox on focus for the Blue Soul specifically, as it could get you stuck in collision