### PR TITLE
Elevator movement fix

### DIFF
--- a/libraries/elevators/scripts/world/events/elevator.lua
+++ b/libraries/elevators/scripts/world/events/elevator.lua
@@ -60,7 +60,16 @@ end
 function Elevator:moveTo(number)
     self.target_floor = number
 
-    self.dir = self.floors[number].dir
+    -- If the target floor is below our current one, move down. Otherwise, move up.
+    if number < self.current_floor then
+    self.dir = -1
+    else
+    self.dir = 1
+    end
+
+    -- If a floor has a dir value set, use that instead
+    if self.floors[number].dir then self.dir = self.floors[number].dir end
+
     self.length = self.floors[number].length or 40
 
     self.con = 100

--- a/libraries/elevators/scripts/world/events/elevatorbuttons.lua
+++ b/libraries/elevators/scripts/world/events/elevatorbuttons.lua
@@ -25,7 +25,7 @@ function ElevatorButtons:onInteract(chara)
         Game.world:startCutscene(function(cutscene)
             cutscene:text("* (Where will you ride the elevator to?)")
 
-            --Miiiiight end up adding a textbox that displays the name of the selected floor later, so I'm leaving this here. - Agent 7
+
             local names = {}
             for i, floor in ipairs(self.elevator.floors) do
                 names[i] = floor.name
@@ -38,6 +38,7 @@ function ElevatorButtons:onInteract(chara)
             local decision = incmenu.decision
             incmenu:remove()
             if decision == self.elevator.current_floor then
+                if Input.pressed("cancel") then return end
                 cutscene:text("* (You're there.)")
                 return
             end

--- a/scripts/world/maps/elevator.lua
+++ b/scripts/world/maps/elevator.lua
@@ -1,8 +1,7 @@
 return {
-  version = "1.9",
+  version = "1.5",
   luaversion = "5.1",
-  tiledversion = "1.9.0",
-  class = "",
+  tiledversion = "1.8.6",
   orientation = "orthogonal",
   renderorder = "right-down",
   width = 16,
@@ -19,7 +18,6 @@ return {
       draworder = "topdown",
       id = 6,
       name = "collision",
-      class = "",
       visible = true,
       opacity = 1,
       offsetx = 0,
@@ -31,7 +29,7 @@ return {
         {
           id = 21,
           name = "",
-          class = "",
+          type = "",
           shape = "rectangle",
           x = 160,
           y = 240,
@@ -44,7 +42,7 @@ return {
         {
           id = 23,
           name = "",
-          class = "",
+          type = "",
           shape = "rectangle",
           x = 201,
           y = 200,
@@ -57,7 +55,7 @@ return {
         {
           id = 24,
           name = "",
-          class = "",
+          type = "",
           shape = "rectangle",
           x = 440,
           y = 240,
@@ -70,7 +68,7 @@ return {
         {
           id = 25,
           name = "",
-          class = "",
+          type = "",
           shape = "rectangle",
           x = 200,
           y = 360,
@@ -83,7 +81,7 @@ return {
         {
           id = 26,
           name = "",
-          class = "",
+          type = "",
           shape = "rectangle",
           x = 360,
           y = 360,
@@ -100,7 +98,6 @@ return {
       draworder = "topdown",
       id = 4,
       name = "objects",
-      class = "",
       visible = true,
       opacity = 1,
       offsetx = 0,
@@ -112,7 +109,7 @@ return {
         {
           id = 6,
           name = "elevatorbuttons",
-          class = "",
+          type = "",
           shape = "rectangle",
           x = 360,
           y = 200,
@@ -125,7 +122,7 @@ return {
         {
           id = 7,
           name = "transition",
-          class = "",
+          type = "",
           shape = "rectangle",
           x = 280,
           y = 480,
@@ -141,7 +138,7 @@ return {
         {
           id = 29,
           name = "elevator",
-          class = "",
+          type = "",
           shape = "rectangle",
           x = 0,
           y = 0,
@@ -156,9 +153,6 @@ return {
             ["dest_1"] = "room1",
             ["dest_2"] = "floor2/lounge",
             ["dest_3"] = "floor3/elevator_hall",
-            ["dir_1"] = -1,
-            ["dir_2"] = 1,
-            ["dir_3"] = 1,
             ["length_1"] = 80,
             ["length_2"] = 80,
             ["length_3"] = 80,
@@ -174,7 +168,6 @@ return {
       draworder = "topdown",
       id = 5,
       name = "markers",
-      class = "",
       visible = true,
       opacity = 1,
       offsetx = 0,
@@ -186,7 +179,7 @@ return {
         {
           id = 5,
           name = "spawn",
-          class = "",
+          type = "",
           shape = "point",
           x = 320,
           y = 440,
@@ -199,7 +192,7 @@ return {
         {
           id = 33,
           name = "entry",
-          class = "",
+          type = "",
           shape = "point",
           x = 320,
           y = 440,
@@ -212,7 +205,7 @@ return {
         {
           id = 32,
           name = "buttons",
-          class = "",
+          type = "",
           shape = "point",
           x = 380,
           y = 260,

--- a/scripts/world/maps/elevator.tmx
+++ b/scripts/world/maps/elevator.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.9" tiledversion="1.9.0" orientation="orthogonal" renderorder="right-down" width="16" height="12" tilewidth="40" tileheight="40" infinite="0" nextlayerid="9" nextobjectid="34">
+<map version="1.8" tiledversion="1.8.6" orientation="orthogonal" renderorder="right-down" width="16" height="12" tilewidth="40" tileheight="40" infinite="0" nextlayerid="9" nextobjectid="34">
  <editorsettings>
   <export target="elevator.lua" format="lua"/>
  </editorsettings>
@@ -26,9 +26,6 @@
     <property name="dest_1" value="room1"/>
     <property name="dest_2" value="floor2/lounge"/>
     <property name="dest_3" value="floor3/elevator_hall"/>
-    <property name="dir_1" type="int" value="-1"/>
-    <property name="dir_2" type="int" value="1"/>
-    <property name="dir_3" type="int" value="1"/>
     <property name="length_1" type="int" value="80"/>
     <property name="length_2" type="int" value="80"/>
     <property name="length_3" type="int" value="80"/>


### PR DESCRIPTION
The direction the elevator will move when moving floors is now dependent on which floor you're currently on. this removes the need for `dir` properties in the elevator event, but if one is defined, it'll still use that.