### PR TITLE
add controller support to Ball Jump button prompts

### DIFF
--- a/scripts/objects/minigame/BallJump/BallJump.lua
+++ b/scripts/objects/minigame/BallJump/BallJump.lua
@@ -161,7 +161,12 @@ function BallJump:draw()
 		else
 			love.graphics.print(score, 6, 0)
 		end
-		love.graphics.print("Press " .. Input.getText("confirm") .. " to jump", 6, 448)
+		if Input.active_gamepad then
+			love.graphics.print("Press        to jump", 6, 448)
+			love.graphics.draw(Input.getTexture("confirm"), 87, 452, 0, 2, 2)
+		else
+			love.graphics.print("Press " .. Input.getText("confirm") .. " to jump", 6, 448)
+		end
 		love.graphics.scale(2,2)
 		for i = 1, self.lives do
 			love.graphics.draw(self.life_icon, -12 + 16 * i, 18)
@@ -198,7 +203,12 @@ function BallJump:draw()
 				love.graphics.printf("Score requirement (" .. self.req_score .. ") not met.", 0, 290, SCREEN_WIDTH, "center")
 			end
 		end
-		love.graphics.printf("Press " .. Input.getText("confirm") .. " to continue.", 0, 350, SCREEN_WIDTH, "center")
+		if Input.active_gamepad then
+			love.graphics.printf("Press        to continue.", 0, 350, SCREEN_WIDTH, "center")
+			love.graphics.draw(Input.getTexture("confirm"), (SCREEN_WIDTH/2) - 53, 354, 0, 2, 2)
+		else
+			love.graphics.printf("Press " .. Input.getText("confirm") .. " to continue.", 0, 350, SCREEN_WIDTH, "center")
+		end
 	end
 	
 	if self.state == "DEAD" or self.state == "TRANSITIONOUT3" then
@@ -206,7 +216,12 @@ function BallJump:draw()
 		love.graphics.printf("Oof.", 0, 100, SCREEN_WIDTH, "center")
 		
 		love.graphics.setFont(self.font)
-		love.graphics.printf("Press " .. Input.getText("confirm") .. " to continue.", 0, 350, SCREEN_WIDTH, "center")
+		if Input.active_gamepad then
+			love.graphics.printf("Press        to continue.", 0, 350, SCREEN_WIDTH, "center")
+			love.graphics.draw(Input.getTexture("confirm"), (SCREEN_WIDTH/2) - 53, 354, 0, 2, 2)
+		else
+			love.graphics.printf("Press " .. Input.getText("confirm") .. " to continue.", 0, 350, SCREEN_WIDTH, "center")
+		end
 	end
 	
 	love.graphics.setColor(1, 1, 1, 1)


### PR DESCRIPTION
Button prompts in Ball Jump used to be replaced by something like `[button:a]` when using a controller. this has been fixed, and they now display an appropriate sprite.