### PR TITLE
Update to Room 1, Fixed Susie Softlock in Wall

### DIFF
--- a/scripts/world/cutscenes/room1.lua
+++ b/scripts/world/cutscenes/room1.lua
@@ -232,6 +232,14 @@ return {
 
             susie:resetSprite()
 
+            -- Special case, prevents softlock if Susie is the leader
+            local susiePlayer = Game:getPartyIndex("susie")
+
+            if susiePlayer == 1 then
+                cutscene:wait(cutscene:walkTo(susie, x, y + 60, 0.5, "down", true))
+            end
+            
+
             cutscene:attachCamera()
 
             cutscene:alignFollowers()


### PR DESCRIPTION
Fixed a bug that got Susie stuck in collision after the blanket cutscene (Only happened when she was the party leader)