### PR TITLE
Fix LightStatMenu crashing with old save files

### DIFF
--- a/libraries/magical-glass/lib.lua
+++ b/libraries/magical-glass/lib.lua
@@ -2244,16 +2244,17 @@ function lib:init()
         end
 
         local offset = 0
-        local show_magic = false
-        for _,party in pairs(Game.party) do
-            if party.lw_stats.magic > 0 then
-                show_magic = true
+        local show_magic = {}
+        for i,party in pairs(Game.party) do
+            show_magic[i] = false
+            if party.lw_stats.magic and party.lw_stats.magic > 0 then
+                show_magic[i] = true
             end
         end
-        if self.always_show_magic or show_magic then
+        if self.always_show_magic or show_magic[self.party_selecting] then
             offset = 18
             love.graphics.print("MG  ", 4, 228 - offset)
-            love.graphics.print(chara:getBaseStats()["magic"]   .. " ("..chara:getEquipmentBonus("magic")   .. ")", 44, 228 - offset)
+            love.graphics.print((chara:getBaseStats()["magic"])   .. " (".. chara:getEquipmentBonus("magic")   .. ")", 44, 228 - offset)
         end
         love.graphics.print("LV  "..chara:getLightLV(), 4, 68 - offset)
         love.graphics.print("HP  "..chara:getHealth().." / "..chara:getStat("health"), 4, 100 - offset)

--- a/mod.lua
+++ b/mod.lua
@@ -152,6 +152,16 @@ function Mod:initializeImportantFlags(new_file)
         self:rollFun()
     end
 
+    if Game:getPartyMember("YOU").lw_stats.magic == nil then
+        likely_old_save = true
+        table.insert(old_save_issues, "Save is missing light world magic stats. Probably pre-Magical Glass.")
+        
+        -- I have no idea what everyone's lw magic stats should be, so uhhhhhhhhh I guess this'll be fine until somebody yells at me for it
+        Game:getPartyMember("YOU").lw_stats.magic = 0
+        Game:getPartyMember("susie").lw_stats.magic = 1
+        Game:getPartyMember("noelle").lw_stats.magic = 1
+    end
+
     if new_file then
         Game:setFlag("vesselChosen", 0)
 


### PR DESCRIPTION
Old saves were missing light world magic stats. That's all there was to it.