### PR TITLE
Added Light checks to party menu

### DIFF
--- a/scripts/objects/world/DarkPartyMenu.lua
+++ b/scripts/objects/world/DarkPartyMenu.lua
@@ -132,7 +132,7 @@ function DarkPartyMenu:onKeyPressed(key)
 			Game.world.player:setActor(Game.party[1].actor)
 			for k,v in pairs(Game.party) do
 				if k > 1 then
-					Game.world:spawnFollower(v.actor)
+					Game.world:spawnFollower(Game:isLight() and v.lw_actor or v.actor)
 				end
 			end
 			Game.world.player:alignFollowers()
@@ -155,13 +155,14 @@ function DarkPartyMenu:onKeyPressed(key)
 				end]]
 				if self.selected_party > 1 then
 					if Game.world.followers[self.selected_party-1] then
-						Game.world.followers[self.selected_party-1]:setActor(Game.party[self.selected_party].actor)
+						Game.world.followers[self.selected_party-1]:setActor(Game:isLight() and Game.party[self.selected_party].lw_actor or Game.party[self.selected_party].actor)
 					else
 						local follower = Game.world:spawnFollower(self.list[self.selected_y][self.selected_x])
+						follower:setActor(Game:isLight() and Game.party[self.selected_party].lw_actor or Game.party[self.selected_party].actor)
 						follower:setFacing("down")
 					end
 				else
-					Game.world.player:setActor(Game.party[1].actor)
+					Game.world.player:setActor(Game:isLight() and Game.party[1].lw_actor or Game.party[1].actor)
 				end
                 self.ui_select:stop()
                 self.ui_select:play()


### PR DESCRIPTION
When using the party menu in the light world, any spawned followers will now use the appropriate light actor.